### PR TITLE
Add prompt to input ticket information

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,7 +41,7 @@ dependencies = [
 
 [[package]]
 name = "czen"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "inquire",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "czen"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [dependencies]

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,7 @@ fn main() -> Result<(), CzenError>{
     })
     .with_render_config(description_render_config())
     .prompt()?;
+    let ticket = Text::new("Enter Github Issues/Jira ticket details if applicable:").prompt()?;
 
     let commit_message = compose_commit_message(
         &commit_type,
@@ -33,6 +34,7 @@ fn main() -> Result<(), CzenError>{
         breaking_change,
         &short_commit_message,
         &long_commit_message,
+        &ticket,
     );
     
     Command::new("git")

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -21,8 +21,14 @@ pub fn compose_commit_message(
     breaking_change: bool,
     short_commit_message: &str,
     long_commit_message: &str,
+    ticket: &str,
 ) -> String {
     let mut commit_message = String::new();
+
+    if !ticket.is_empty() {
+        commit_message.push_str(&format!("[{}] ", ticket));
+        
+    }
 
     if !scope.is_empty(){
         commit_message.push_str(&format!("{}({})", commit_type, scope));


### PR DESCRIPTION
Adds a text prompt to allow the user to input and github issues or jira ticket details. Optional.